### PR TITLE
Kmeans fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class KMeans:
         centers = random.sample(list(X), k)
         for i in range(n_iter):
             clusters = np.argmin(cdist(X, centers), axis=1)
-            centers = np.array([X[clusters == c].mean(0) for c in clusters])
+            centers = np.array([X[clusters == c].mean(0) for c in range(k)])
         return clusters
 ```
 

--- a/napkin_ml/models.py
+++ b/napkin_ml/models.py
@@ -67,5 +67,5 @@ class KMeans:
         centers = random.sample(list(X), k)
         for _ in range(n_iter):
             clusters = np.argmin(cdist(X, centers), axis=1)
-            centers = np.array([X[clusters == c].mean(0) for c in clusters])
+            centers = np.array([X[clusters == c].mean(0) for c in range(k)])
         return clusters


### PR DESCRIPTION
It seems that KMeans has slightly incorrect code line. It results in computing as much clusters as data points.

Code to reproduce bug:
```python
from sklearn.datasets import make_blobs
from napkin_ml import KMeans

X, y = make_blobs(n_samples=300, centers=3, random_state=1)
kmeans = KMeans()
clusters = kmeans.fit(X, 3)
print(np.unique(clusters))
```

Result: array([0, 1, 3])
Expected: [0, 1, 2]
Where is the 2nd cluster? Where is the 3rd cluster appeared from?
